### PR TITLE
Added logic to create a shimgoose Schema from a Mongoose Schema, and read in existing pre/post hooks

### DIFF
--- a/index-mongooseSchema.js
+++ b/index-mongooseSchema.js
@@ -1,0 +1,139 @@
+const mongoose = require('mongoose');
+const shimgoose = require('./shimgoose');
+const externalapi  = require('./externalapi');
+
+main().catch(err => console.log(err));
+
+async function main() {
+  // connect to MongoDB
+  await mongoose.connect('mongodb://root:example@localhost:27017/test', {
+    authSource: 'admin'
+  });
+  
+  const mongooseTacoSchema = new mongoose.Schema({
+    protein: String,
+    spicy: Boolean,
+  })
+
+  // these pre/post hooks should continue to work as expected, with caveats
+  mongooseTacoSchema.pre('findOne', function(next) {
+    console.log('pre findOne 1');
+    next();
+  });
+  mongooseTacoSchema.pre('findOne', function(next) {
+    console.log('pre findOne 2');
+    next();
+  });
+  mongooseTacoSchema.post('findOne', function(next) {
+    console.log('post findOne 1');
+    next()
+  });
+  mongooseTacoSchema.post('findOne', function(next) {
+    console.log('post findOne 2');
+    next()
+  });
+  mongooseTacoSchema.pre('save', function(next) {
+    console.log('pre save 1');
+    next();
+  });
+  mongooseTacoSchema.pre('save', function(next) {
+    console.log('pre save 2');
+    next();
+  });
+  mongooseTacoSchema.post('save', function(next) {
+    console.log('post save 1');
+    next()
+  });
+  mongooseTacoSchema.post('save', function(next) {
+    console.log('post save 2');
+    next()
+  });
+  mongooseTacoSchema.post('deleteOne', function(next) {
+    console.log('post deleteOne 1');
+    next()
+  });
+  mongooseTacoSchema.post('deleteOne', function(next) {
+    console.log('post deleteOne 2');
+    next()
+  });
+
+  // use shim schema to make sure hooks are intercepted and registered properly
+  const tacoSchema = new shimgoose.Schema(mongooseTacoSchema);
+
+  // create the shim model using the shim schema
+  const Taco = shimgoose.model('Taco', tacoSchema, {
+    fetch: externalapi.fetchTacos,
+    save: externalapi.saveTaco,
+    delete: externalapi.deleteTaco,
+  });
+
+  // this find() call will bypass Mongoose and fetch using our API instead
+  console.log('attempting to find all tacos');
+  try {
+    let tacos = await Taco.find();
+    console.log('Tacos found:', tacos);
+  } catch (err) {
+    console.log('shimmed Model.find() failed:', err);
+  }
+
+  // this findOne() call will bypass Mongoose and fetch using our API instead
+  console.log('attempting to find a taco');
+  try {
+    let taco = await Taco.findOne({ _id: "62056e13d30a1cb15f585ce6" /* chorizo (external data) */ });
+    console.log('Taco found:', taco);
+    console.log('doc is instanceof mongoose.Model?', taco instanceof mongoose.Model);
+    console.log('doc is instanceof mongoose.Document?', taco instanceof mongoose.Document);
+  } catch (err) {
+    console.log('shimmed Model.findOne() failed:', err);
+  }
+
+  // this save() call will bypass Mongoose and save using our API instead
+  console.log('attempting to create a taco (save() returning a promise)');
+  try {
+    let taco = await Taco.new({ protein: 'alligator', spicy: false }).save();
+    console.log('Taco created:', taco);
+    console.log('doc is instanceof mongoose.Model?', taco instanceof mongoose.Model);
+    console.log('doc is instanceof mongoose.Document?', taco instanceof mongoose.Document);
+  } catch (err) {
+    console.log('shimmed Document.save() failed:', err);
+  }
+
+  // can also use save() with a callback instead of returning a promise
+  console.log('attempting to create a taco (save() invoking a callback)');
+  Taco.new({protein: 'black bean', spicy: true}).save((err, taco) => {
+    if (err) {
+      console.log('shimmed Document.save() failed:', err);
+    } else {
+      console.log('Taco created:', taco);
+      console.log('doc is instanceof mongoose.Model?', taco instanceof mongoose.Model);
+      console.log('doc is instanceof mongoose.Document?', taco instanceof mongoose.Document);
+    }
+  })
+
+  // this find() call will bypass Mongoose and fetch using our API instead
+  console.log('attempting to find all tacos');
+  try {
+    let tacos = await Taco.find();
+    console.log('Tacos found:', tacos);
+  } catch (err) {
+    console.log('shimmed Model.find() failed:', err);
+  }
+
+  // this deleteOne() call will bypass Mongoose and fetch using our API instead
+  console.log('attempting to delete a taco');
+  try {
+    let result = await Taco.deleteOne({ _id: "62056e13d30a1cb15f585ce6" /* chorizo (external data) */ });
+    console.log(result.deletedCount, 'Taco deleted');
+  } catch (err) {
+    console.log('shimmed Model.deleteOne() failed:', err);
+  }
+
+  // this find() call will bypass Mongoose and fetch using our API instead
+  console.log('attempting to find all tacos');
+  try {
+    let tacos = await Taco.find();
+    console.log('Tacos found:', tacos);
+  } catch (err) {
+    console.log('shimmed Model.find() failed:', err);
+  }
+}

--- a/shimgoose.js
+++ b/shimgoose.js
@@ -2,10 +2,22 @@ const mongoose = require('mongoose');
 
 // Schema wraps the Mongoose Schema type and keeps track of pre/post hooks manually.
 function Schema(definition) {
-  this._mgSchema = new mongoose.Schema(definition);
   this.hooks = {
     pre: {},
     post: {}
+  }
+  if(definition instanceof mongoose.Schema) {
+    var schema = this;
+
+    this._mgSchema = definition;
+    definition.s.hooks._pres.forEach((values, key) => {
+      values.forEach(_pre => schema.pre(key, _pre.fn));
+    });
+    definition.s.hooks._posts.forEach((values, key) => {
+      values.forEach(_post => schema.post(key, _post.fn));
+    });
+  } else {
+    this._mgSchema = new mongoose.Schema(definition);
   }
 }
 


### PR DESCRIPTION
This adds an approach which takes the mongoose schema instead of just a definition json.  The primary difference is when it collects it, instead of creating a mongoose schema, it uses the provided one, and reads the hooks out of the mongoose schema and loads them into the shimgoose schema.

I am wondering if there is value-add by having a shimgoose schema, or if shimgoose should just run on a mongoose schema.